### PR TITLE
35 persistencia de entidad user

### DIFF
--- a/src/main/java/com/imb4/gc/p3/gr1/controller/UserController.java
+++ b/src/main/java/com/imb4/gc/p3/gr1/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.imb4.gc.p3.gr1.controller;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.imb4.gc.p3.gr1.entity.User;
+import com.imb4.gc.p3.gr1.service.IUserService;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    @Autowired
+    private IUserService userService;
+
+    @GetMapping
+    public List<User> getAll() {
+        return userService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getById(@PathVariable Long id) {
+        User user = userService.getById(id);
+        if (user == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping
+    public User save(@RequestBody User user) {
+        return userService.save(user);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> update(@PathVariable Long id, @RequestBody User userDetails) {
+        if (!userService.exists(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        userDetails.setId(id);
+        User updatedUser = userService.save(userDetails);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!userService.exists(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        userService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/imb4/gc/p3/gr1/repository/UserRepository.java
+++ b/src/main/java/com/imb4/gc/p3/gr1/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.imb4.gc.p3.gr1.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.imb4.gc.p3.gr1.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/imb4/gc/p3/gr1/service/IUserService.java
+++ b/src/main/java/com/imb4/gc/p3/gr1/service/IUserService.java
@@ -1,0 +1,12 @@
+package com.imb4.gc.p3.gr1.service;
+
+import java.util.List;
+import com.imb4.gc.p3.gr1.entity.User;
+
+public interface IUserService {
+    List<User> getAll();
+    User getById(Long id);
+    User save(User user);
+    void delete(Long id);
+    boolean exists(Long id);
+}

--- a/src/main/java/com/imb4/gc/p3/gr1/service/UserServiceImpl.java
+++ b/src/main/java/com/imb4/gc/p3/gr1/service/UserServiceImpl.java
@@ -1,0 +1,39 @@
+package com.imb4.gc.p3.gr1.service;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.imb4.gc.p3.gr1.entity.User;
+import com.imb4.gc.p3.gr1.repository.UserRepository;
+
+@Service
+public class UserServiceImpl implements IUserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public List<User> getAll() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    public User getById(Long id) {
+        return userRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean exists(Long id) {
+        return userRepository.existsById(id);
+    }
+}


### PR DESCRIPTION
Aca cree el crud de usuarios, usando postman puede probar lo endpoints:

obtener un usuario) http://localhost:8080/api/user/{aca-va-el-id}
![image](https://github.com/ahumadamob/2024_gc_p3_g1_sf/assets/68260203/2aff5919-17b8-44bc-8845-231af4d87528)

obtener todos los usuarios) http://localhost:8080/api/user
![image](https://github.com/ahumadamob/2024_gc_p3_g1_sf/assets/68260203/6815f946-f4fc-453b-a9c8-d85d9d69f31a)

insertar un usuario) http://localhost:8080/api/user
![image](https://github.com/ahumadamob/2024_gc_p3_g1_sf/assets/68260203/fbf88899-eaa2-4d6e-bccd-5d3040d42db7)

actualizar un usuario) http://localhost:8080/api/user/{aca-va-el-id}
![image](https://github.com/ahumadamob/2024_gc_p3_g1_sf/assets/68260203/fb9652b8-049d-4396-b8e9-c8c0f74d4865)

eliminar un usuario) http://localhost:8080/api/user/{aca-va-el-id}
![image](https://github.com/ahumadamob/2024_gc_p3_g1_sf/assets/68260203/afbd8f43-cab4-4034-98a9-eae1d3ef7bd6)
